### PR TITLE
Add zero width spaces

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <link href="index.css" rel="stylesheet">
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <link rel="shortcut icon" type="image/png" href="logo.png" />
-    <title>NGINX Proxy</title>
+    <title>N​G​I​N​X P​r​o​x​y</title>
 </head>
 
 <body>


### PR DESCRIPTION
Add zero width spaces for every letter for the keywords "nginx" and "proxy" in the title to make it a bit harder for filters to pick up on those keywords to block the site.