### PR TITLE
add railway deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/bFBWOL?referralCode=erics)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/bFBWOL)
 
 Demo: https://womginx.arph.org
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/bFBWOL?referralCode=erics)
+
 Demo: https://womginx.arph.org
 
 ~~Heroku Docker demo: https://womginx.herokuapp.com~~ taken down for now. If you need one, deploy one using the button above or use the demo link.


### PR DESCRIPTION
Adds an option to deploy the proxy using https://railway.app. Uses my fork because railway currently blocks everything that contains the word "youtube". I'll update it to use the main repo when railway fixes this issue.